### PR TITLE
Fixed log spam when unable to calculate weight of non-armor item

### DIFF
--- a/src/main/java/com/elenai/feathers/api/FeathersHelper.java
+++ b/src/main/java/com/elenai/feathers/api/FeathersHelper.java
@@ -270,7 +270,6 @@ public class FeathersHelper {
 		} else if (itemStack.getItem() == Items.AIR) {
 			return 0;
 		}
-		Feathers.logger.warn("Attempted to calculate weight of non armor item: " + itemStack.getDescriptionId());
 		return 0;
 	}
 


### PR DESCRIPTION
#20 was supposedly fixed around a year ago, but the commit to fix it never made it in to the actual product and was somehow lost. This pull request implements the fix in [8d954e6](https://github.com/ElenaiDev/Feathers/commit/8d954e6af1e0ae570a2f948919a9219f21bd9026) bug for bug.

This should also fix #37 once it is merged.